### PR TITLE
Update editing sours

### DIFF
--- a/app/Http/Controllers/SourController.php
+++ b/app/Http/Controllers/SourController.php
@@ -18,7 +18,8 @@ class SourController extends Controller
             'percent' => ['sometimes', 'numeric', 'gte:0', 'nullable'],
             'comments' => ['sometimes', 'string', 'max:280', 'nullable'],
             'rating' => ['required', 'numeric', 'gte:0', 'lte:10', 'nullable'],
-            'image' => ['sometimes', 'mimes:heic,jpg,jpeg,png,bmp,gif,svg,webp', 'max:3000', 'nullable'],
+            'image' => ['sometimes', 'mimes:heic,jpg,jpeg,png,bmp,gif,svg,webp', 'nullable'],
+//            'image' => ['sometimes', 'mimes:heic,jpg,jpeg,png,bmp,gif,svg,webp', 'max:3000', 'nullable'],
             'category_id' => ['sometimes', 'numeric', 'gte:0', 'nullable']
         ],
             [ 'name.unique' => 'That sour has already been rated!', ]
@@ -27,7 +28,11 @@ class SourController extends Controller
         $validated['hasLactose'] = request()->has('hasLactose');
         if (request()->has('image')) {
             $validated['image'] = time() . '.' . 'jpg';
-            Image::make(request()->file('image'))->save(public_path('/storage/sours/') . $validated['image']);
+            Image::make(request()->file('image'))
+                ->resize(512, null, function ($constraint) {
+                    $constraint->aspectRatio();
+                    })
+                ->save(public_path('/storage/sours/') . $validated['image']);
         }
 
         auth()->user()->sours()->create($validated);
@@ -77,7 +82,11 @@ class SourController extends Controller
         $validated['hasLactose'] = request()->has('hasLactose');
         if (request()->has('image')) {
             $validated['image'] = time() . '.' . 'jpg';
-            Image::make(request()->file('image'))->save(public_path('/storage/sours/') . $validated['image']);
+            Image::make(request()->file('image'))
+                ->resize(512, null, function ($constraint) {
+                    $constraint->aspectRatio();
+                })
+                ->save(public_path('/storage/sours/') . $validated['image']);
         }
 
         $sour->update($validated);

--- a/app/Http/Controllers/SourController.php
+++ b/app/Http/Controllers/SourController.php
@@ -17,7 +17,8 @@ class SourController extends Controller
             }), 'max:100'],
             'percent' => ['sometimes', 'numeric', 'gte:0', 'nullable'],
             'comments' => ['sometimes', 'string', 'max:280', 'nullable'],
-            'rating' => ['required', 'numeric', 'gte:0', 'nullable'],
+            'rating' => ['required', 'numeric', 'gte:0', 'lte:10', 'nullable'],
+//            'rating' => ['required', 'numeric', 'between:0,10', 'nullable'],
             'image' => ['sometimes', 'mimes:heic,jpg,jpeg,png,bmp,gif,svg,webp', 'max:3000', 'nullable'],
             'category_id' => ['sometimes', 'numeric', 'gte:0', 'nullable']
         ],

--- a/app/Http/Controllers/SourController.php
+++ b/app/Http/Controllers/SourController.php
@@ -18,7 +18,6 @@ class SourController extends Controller
             'percent' => ['sometimes', 'numeric', 'gte:0', 'nullable'],
             'comments' => ['sometimes', 'string', 'max:280', 'nullable'],
             'rating' => ['required', 'numeric', 'gte:0', 'lte:10', 'nullable'],
-//            'rating' => ['required', 'numeric', 'between:0,10', 'nullable'],
             'image' => ['sometimes', 'mimes:heic,jpg,jpeg,png,bmp,gif,svg,webp', 'max:3000', 'nullable'],
             'category_id' => ['sometimes', 'numeric', 'gte:0', 'nullable']
         ],
@@ -68,7 +67,7 @@ class SourController extends Controller
             'name' => ['sometimes', 'required', 'string', Rule::unique('sours', 'name')->ignore($sour->id), 'max:100'],
             'percent' => ['sometimes', 'numeric', 'gte:0', 'nullable'],
             'comments' => ['sometimes', 'string', 'max:280', 'nullable'],
-            'rating' => ['sometimes', 'numeric', 'gte:0', 'nullable'],
+            'rating' => ['sometimes', 'numeric', 'gte:0', 'lte:10', 'nullable'],
             'image' => ['sometimes', 'mimes:heic,jpg,jpeg,png,bmp,gif,svg,webp', 'max:3000', 'nullable'],
             'category_id' => ['sometimes', 'numeric', 'gte:0', 'nullable']
         ],

--- a/app/Http/Controllers/SourController.php
+++ b/app/Http/Controllers/SourController.php
@@ -69,7 +69,9 @@ class SourController extends Controller
     {
         $validated = request()->validate([
             'company' => ['sometimes', 'required', 'string', 'max:100'],
-            'name' => ['sometimes', 'required', 'string', Rule::unique('sours', 'name')->ignore($sour->id), 'max:100'],
+            'name' => ['sometimes', 'required', 'string', 'max:100', Rule::unique('sours', 'name')->where(function ($query) {
+                    return $query->where('user_id', auth()->user()->id);
+                 })->ignore($sour->id)],
             'percent' => ['sometimes', 'numeric', 'gte:0', 'nullable'],
             'comments' => ['sometimes', 'string', 'max:280', 'nullable'],
             'rating' => ['sometimes', 'numeric', 'gte:0', 'lte:10', 'nullable'],

--- a/resources/views/components/sours/edit-sour.blade.php
+++ b/resources/views/components/sours/edit-sour.blade.php
@@ -1,4 +1,4 @@
-<form method="POST" action="{{ route('sours.update', $sour->id) }}" class="p-2" enctype="multipart/form-data">
+<form method="POST" action="{{ route('sours.update', $sour) }}" class="p-2" enctype="multipart/form-data">
     @csrf
     @method('PATCH')
     <h2 class="text-white text-center text-2xl uppercase font-bold">Edit Bevvie</h2>
@@ -86,6 +86,6 @@
 
 
     <x-inputs.button class="mt-6">
-        {{ __('Edit') }}
+        {{ __('Save') }}
     </x-inputs.button>
 </form>

--- a/resources/views/components/sours/edit-sour.blade.php
+++ b/resources/views/components/sours/edit-sour.blade.php
@@ -8,7 +8,7 @@
         <div class="mt-4 md:grow">
             <x-inputs.label for="name" :value="__('Name*')" />
 
-            <x-inputs.input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name', $sour->name)" required autofocus />
+            <x-inputs.input id="name" class="block mt-1 w-full" type="text" name="name" :value="$sour->name" required autofocus />
 
             <x-inputs.error name="name" />
         </div>
@@ -17,7 +17,7 @@
         <div class="mt-4 md:grow">
             <x-inputs.label for="company" :value="__('Brewery*')" />
 
-            <x-inputs.input id="company" class="block mt-1 w-full" type="text" name="company" :value="old('company', $sour->company)" required />
+            <x-inputs.input id="company" class="block mt-1 w-full" type="text" name="company" :value="$sour->company" required />
 
             <x-inputs.error name="company" />
         </div>
@@ -29,7 +29,7 @@
             <div>
                 <x-inputs.label for="rating" :value="__('Rating* (as decimal number)')" />
 
-                <x-inputs.input id="rating" class="block mt-1 w-full" type="text" name="rating" :value="old('rating', $sour->rating)" />
+                <x-inputs.input id="rating" class="block mt-1 w-full" type="text" name="rating" :value="$sour->rating" />
 
                 <x-inputs.error name="rating" />
             </div>
@@ -37,7 +37,7 @@
             <div>
                 <x-inputs.label for="percent" :value="__('Percent (as decimal number)')" />
 
-                <x-inputs.input id="percent" class="block mt-1 w-full" type="text" name="percent" :value="old('percent', $sour->percent)" />
+                <x-inputs.input id="percent" class="block mt-1 w-full" type="text" name="percent" :value="$sour->percent" />
 
                 <x-inputs.error name="percent" />
             </div>
@@ -70,7 +70,7 @@
     <div class="mt-4">
         <x-inputs.label for="comments" :value="__('Comments')" />
 
-        <x-inputs.textarea id="comments" class="block mt-1 w-full" rows="4" name="comments" :value="old('comments', $sour->comments)" />
+        <x-inputs.textarea id="comments" class="block mt-1 w-full" rows="4" name="comments" :value="$sour->comments" />
 
         <x-inputs.error name="comments" />
     </div>
@@ -79,7 +79,7 @@
     <div class="mt-4">
         <x-inputs.label for="image" :value="__('Image')" />
 
-        <x-inputs.input id="image" class="block mt-1 w-full rounded-none" type="file" name="image" :value="old('image')" />
+        <x-inputs.input id="image" class="block mt-1 w-full rounded-none" type="file" name="image" :value="$sour->image" />
 
         <x-inputs.error name="image" />
     </div>

--- a/tests/Feature/Auth/UpdateUserTest.php
+++ b/tests/Feature/Auth/UpdateUserTest.php
@@ -15,6 +15,7 @@ class UpdateUserTest extends TestCase
     public function test_update_screen_can_be_rendered()
     {
         $user = User::factory()->create();
+        $this->actingAs($user);
 
         $response = $this->get(route('users.edit', $user));
 
@@ -28,7 +29,7 @@ class UpdateUserTest extends TestCase
         $this->actingAs($user);
 
         $this->patch(route('users.update', $user), ['name' => 'Nick'])
-            ->assertOk();
+            ->assertRedirect(route('users.edit', $user));
 
         $this->assertArrayHasKey('name', User::all()->first()->toArray());
         $this->assertContains('Nick', User::all()->first()->toArray());
@@ -40,7 +41,7 @@ class UpdateUserTest extends TestCase
         $this->actingAs($user);
 
         $this->patch(route('users.update', $user), ['email' => 'nick@is.cool'])
-            ->assertOk();
+            ->assertRedirect(route('users.edit', $user));
 
         $this->assertArrayHasKey('email', User::all()->first()->toArray());
         $this->assertContains('nick@is.cool', User::all()->first()->toArray());
@@ -52,7 +53,7 @@ class UpdateUserTest extends TestCase
         $this->actingAs($user);
 
         $this->patch(route('users.update', $user), ['profileImage' => UploadedFile::fake()->image('test.png')])
-            ->assertOk();
+            ->assertRedirect(route('users.edit', $user));
 
         $this->assertArrayHasKey('profileImage', User::all()->first()->toArray());
         $this->assertNotNull(User::all()->first()->profileImage);
@@ -96,7 +97,7 @@ class UpdateUserTest extends TestCase
         $this->patchJson(route('users.update', $user), [
             'email' => 'test@test.com'
         ])
-            ->assertOk();
+            ->assertRedirect(route('users.edit', $user));
     }
 
     /**

--- a/tests/Feature/Sours/AddSoursTest.php
+++ b/tests/Feature/Sours/AddSoursTest.php
@@ -187,15 +187,24 @@ class AddSoursTest extends TestCase
                 'errorMessage' => [
                     'rating' => [
                         'The rating must be a number.',
-                        'The rating must be greater than or equal to 0.'
+                        'The rating must be greater than or equal to 0.',
+                        'The rating must be less than or equal to 10.',
                     ]
                 ],
             ],
             'rating must greater than or equal to 0' => [
-                'invalidAttribute' => $this->setInvalidAttribute('rating', -4),
+                'invalidAttribute' => $this->setInvalidAttribute('rating', -1),
                 'errorMessage' => [
                     'rating' => [
                         'The rating must be greater than or equal to 0.'
+                    ]
+                ],
+            ],
+            'rating must be less than or equal to 10' => [
+                'invalidAttribute' => $this->setInvalidAttribute('rating', 11),
+                'errorMessage' => [
+                    'rating' => [
+                        'The rating must be less than or equal to 10.'
                     ]
                 ],
             ],

--- a/tests/Feature/Sours/AddSoursTest.php
+++ b/tests/Feature/Sours/AddSoursTest.php
@@ -6,7 +6,9 @@ use App\Models\Sour;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Intervention\Image\Facades\Image;
 use Tests\TestCase;
 
 class AddSoursTest extends TestCase
@@ -74,6 +76,29 @@ class AddSoursTest extends TestCase
                 "message" => "The given data was invalid."
             ]);
     }
+
+    //TODO: Make this test work
+//    public function test_image_is_less_than_500KB()
+//    {
+//        $user = User::factory()->create();
+//        $this->actingAs($user);
+//
+//        $attributes = [
+//            'company' => 'Fixed Gear Brewing',
+//            'name' => 'Cherry Training Wheels',
+//            'percent' => 4.0,
+//            'comments' => 'Cherry Training Wheels is soured with our lactobacillus blend to generate a tart lactic acidity, then hopped generously with North American hops to bring out notes of lemon peel. Blended with fresh cherry juice and pours a beautiful pink.',
+//            'rating' => 9,
+//            'hasLactose' => true,
+//            'image' => UploadedFile::fake()->image('test.png')->size(5000)
+//        ];
+//
+//        $this->postJson(route('sours.store'), $attributes);
+//
+//        $fileName = Sour::all()->first()->image;
+////        $fileSize = Storage::size(storage_path('app/public/sours/') . $fileName);
+//        $this->assertDatabaseCount('sours', 1);
+//    }
 
     /**
      * @dataProvider invalidDataAddSour

--- a/tests/Feature/Sours/EditSourTest.php
+++ b/tests/Feature/Sours/EditSourTest.php
@@ -191,7 +191,8 @@ class EditSourTest extends TestCase
                 'errorMessage' => [
                     "rating" => [
                         "The rating must be a number.",
-                        "The rating must be greater than or equal to 0."
+                        "The rating must be greater than or equal to 0.",
+                        "The rating must be less than or equal to 10.",
                     ]
                 ]
             ],
@@ -201,6 +202,15 @@ class EditSourTest extends TestCase
                 'errorMessage' => [
                     "rating" => [
                         "The rating must be greater than or equal to 0."
+                    ]
+                ]
+            ],
+            'rating must be less than or equal to 10' => [
+                'attribute' => 'rating',
+                'attributeValue' => 11,
+                'errorMessage' => [
+                    "rating" => [
+                        "The rating must be less than or equal to 10."
                     ]
                 ]
             ],

--- a/tests/Feature/Sours/EditSourTest.php
+++ b/tests/Feature/Sours/EditSourTest.php
@@ -40,6 +40,19 @@ class EditSourTest extends TestCase
 //        $this->assertEquals($sour->toArray(), Sour::all()->first()->toArray());
     }
 
+    public function test_sour_can_be_edited_while_keeping_name_the_same()
+    {
+        $this->actingAs(User::factory()->create());
+
+        $sour = Sour::factory()->create(['name' => 'Test']);
+
+        $this->patchJson(route('sours.update', $sour), [
+            'name' => 'Test',
+            'percent' => 6.9,
+        ])
+            ->assertRedirect(route('sours.index'));
+    }
+
     public function test_sour_cannot_be_edited_by_unauthenticated_user()
     {
         $sour = Sour::factory()->create();


### PR DESCRIPTION
- Fix breaking tests
- Fixed editing, user must have unique sour name but sour name does not need to be unique to other users
- Fixed edit modal, modal shows correct sour information when error is present (still shows error but saves as expected)
- Resize all images to 512px using imagemagick